### PR TITLE
Using BCryptPasswordEncoder in spring security to encrypt and decrypt login passwords In Serving-Admin

### DIFF
--- a/document/docs/service/admin.md
+++ b/document/docs/service/admin.md
@@ -5,6 +5,8 @@ serving-admin提供了FATE-Serving集群的可视化操作界面，依赖zookeep
 ### 功能介绍
 #### 用户管理
 默认用户：admin，默认密码：admin，用户可在[conf/application.properties](config/admin.md)中修改预设用户。    
+除此之外serving-admin提供一个基本的登录密码加解密功能，用户可在[conf/application.properties](config/application.properties)
+中通过设置admin.isEncrypt参数为true（默认为false关闭），同时根据spring.security中的BCryptPasswordEncoder库对密码进行提前处理并预设为默认密码。
 serving-admin仅实现简单的用户登录，用户可业务需求，自行实现登录逻辑，或接入第三方平台。
 
 #### 节点管理

--- a/fate-serving-admin/pom.xml
+++ b/fate-serving-admin/pom.xml
@@ -51,6 +51,11 @@
             <version>${fate.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
 
 
         <!--<dependency>

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/LoginController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/LoginController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -51,7 +52,7 @@ public class LoginController {
     private String username;
 
     @Value("${admin.password}")
-    private String password;
+    private String hashedPassword;
 
     @Autowired
     private Cache cache;
@@ -65,7 +66,7 @@ public class LoginController {
         Preconditions.checkArgument(StringUtils.isNotBlank(password), "parameter password is blank");
 
         ReturnResult result = new ReturnResult();
-        if (username.equals(this.username) && password.equals(this.password)) {
+        if (username.equals(this.username) && new BCryptPasswordEncoder().matches(password, this.hashedPassword)) {
             String userInfo = StringUtils.join(Arrays.asList(username, password), "_");
             String token = EncryptUtils.encrypt(Dict.USER_CACHE_KEY_PREFIX + userInfo, EncryptMethod.MD5);
             cache.put(token, userInfo, MetaInfo.PROPERTY_CACHE_TYPE.equalsIgnoreCase("local") ? MetaInfo.PROPERTY_LOCAL_CACHE_EXPIRE : MetaInfo.PROPERTY_REDIS_EXPIRE);

--- a/fate-serving-admin/src/main/resources/application.properties
+++ b/fate-serving-admin/src/main/resources/application.properties
@@ -28,5 +28,7 @@ zk.url=localhost:2181,localhost:2182,localhost:2183
 # username & password
 admin.username=admin
 admin.password=admin
+# 登录密码是否加密, 默认false关闭, 为true时请采用spring-security中BCryptPasswordEncoder进行提前加密处理
+admin.isEncrypt=false
 
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER


### PR DESCRIPTION
@forgivedengkai 

serving-admin的登录密码目前在spring的application.properties文件中采用明文存储，安全性较低；我这边采用spring security的BCryptPasswordEncoder对登录密码的存储与校验进行加解密处理，提高安全性。