### PR TITLE
去掉无用线程池实例及部分代码优化

### DIFF
--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ServiceController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ServiceController.java
@@ -128,8 +128,6 @@ public class ServiceController {
         totalSize = resultList.size();
 
         resultList = resultList.stream().sorted((Comparator.comparing(o -> (o.getProject() + o.getEnvironment())))).collect(Collectors.toList());
-//        resultList = resultList.stream().sorted((Comparator.comparingInt(o -> (o.getProject() + o.getEnvironment()).hashCode()))).collect(Collectors.toList());
-        // Pagination
         int totalPage = (resultList.size() + pageSize - 1) / pageSize;
         if (page <= totalPage) {
             resultList = resultList.subList((page - 1) * pageSize, Math.min(page * pageSize, resultList.size()));

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/ComponentService.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/ComponentService.java
@@ -88,18 +88,12 @@ public class ComponentService {
             }
             return false;
         }).map(Map.Entry::getKey).findFirst();
-        if(project.isPresent())
-            return project.get();
-        else
-            return "";
+        return project.orElse("");
     }
 
     public boolean isAllowAccess(String host, int port) {
         Set<String> whitelist = getWhitelist();
-        if (whitelist != null && whitelist.contains(host + ":" + port)) {
-            return true;
-        }
-        return false;
+        return whitelist != null && whitelist.contains(host + ":" + port);
     }
 
     @Scheduled(cron = "0/5 * * * * ?")

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/HealthCheckService.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/HealthCheckService.java
@@ -47,8 +47,6 @@ public class HealthCheckService implements InitializingBean {
     GrpcConnectionPool grpcConnectionPool = GrpcConnectionPool.getPool();
     Map<String,Object> healthRecord = new ConcurrentHashMap<>();
 
-    private static ThreadPoolExecutor executor = ThreadPoolUtil.newThreadPoolExecutor();
-
     public    Map  getHealthCheckInfo(){
         return   healthRecord;
     }

--- a/fate-serving-register/src/main/java/com/webank/ai/fate/register/zookeeper/ZookeeperRegistry.java
+++ b/fate-serving-register/src/main/java/com/webank/ai/fate/register/zookeeper/ZookeeperRegistry.java
@@ -117,24 +117,22 @@ public class ZookeeperRegistry extends FailbackRegistry {
 
     @Override
     public void doRegisterComponent(URL url) {
-        if(url==null) {
+        if(url == null) {
             String hostAddress = NetUtils.getLocalIp();
             String path = PATH_SEPARATOR + DEFAULT_COMPONENT_ROOT + PATH_SEPARATOR + project + PATH_SEPARATOR + hostAddress + ":" + port;
             url = new URL(path, Maps.newHashMap());
             //url=url.addParameter(Constants.INSTANCE_ID, AbstractRegistry.INSTANCE_ID);
         }
 
-        if(url !=null) {
-            String path = url.getPath();
-            Map content = new HashMap();
-            content.put(Constants.INSTANCE_ID, AbstractRegistry.INSTANCE_ID);
-            content.put(Constants.TIMESTAMP_KEY, System.currentTimeMillis());
-            content.put(Dict.VERSION, MetaInfo.CURRENT_VERSION);
-            this.zkClient.create(path, JsonUtil.object2Json(content), true);
-            this.componentUrl = url;
+        String path = url.getPath();
+        Map content = new HashMap();
+        content.put(Constants.INSTANCE_ID, AbstractRegistry.INSTANCE_ID);
+        content.put(Constants.TIMESTAMP_KEY, System.currentTimeMillis());
+        content.put(Dict.VERSION, MetaInfo.CURRENT_VERSION);
+        this.zkClient.create(path, JsonUtil.object2Json(content), true);
+        this.componentUrl = url;
 
-            logger.info("register component {} ", path);
-        }
+        logger.info("register component {} ", path);
     }
 
 
@@ -155,7 +153,6 @@ public class ZookeeperRegistry extends FailbackRegistry {
         }else{
             System.err.println("componentUrl is null");
         }
-
     }
 
 
@@ -253,7 +250,6 @@ public class ZookeeperRegistry extends FailbackRegistry {
         param = param + "&";
         param = param + Constants.TIMESTAMP_KEY + "=" + System.currentTimeMillis();
         String key = serviceName;
-        boolean appendParam = false;
         if (version != 0) {
             param = param + "&" + Constants.VERSION + "=" + version;
         }
@@ -271,14 +267,10 @@ public class ZookeeperRegistry extends FailbackRegistry {
             if (serviceWrapper.getWeight() != null) {
                 parameters.put(Constants.WEIGHT_KEY, String.valueOf(serviceWrapper.getWeight()));
             }
-//            if (serviceWrapper.getVersion() != null) {
-//                parameters.put(Constants.VERSION_KEY, String.valueOf(serviceWrapper.getVersion()));
-//            }
         } else {
             serviceWrapper = new ServiceWrapper();
             serviceWrapper.setRouterMode(parameters.get(Constants.ROUTER_MODE));
             serviceWrapper.setWeight(parameters.get(Constants.WEIGHT_KEY) != null ? Integer.valueOf(parameters.get(Constants.WEIGHT_KEY)) : null);
-            //serviceWrapper.setVersion(parameters.get(Constants.VERSION_KEY) != null ? Long.valueOf(parameters.get(Constants.VERSION_KEY)) : null);
             this.getServiceCacheMap().put(url.getEnvironment() + "/" + url.getPath(), serviceWrapper);
         }
     }
@@ -391,8 +383,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
             throw new RuntimeException("Failed to register service:"+ service +" ,acquire serviceName is blank");
         }
 
-        URL url = URL.valueOf(protocol + "://" + hostAddress + ":" + hostPort + Constants.PATH_SEPARATOR + parseRegisterService(serviceName, service));
-        return url;
+        return URL.valueOf(protocol + "://" + hostAddress + ":" + hostPort + Constants.PATH_SEPARATOR + parseRegisterService(serviceName, service));
     }
 
     public void addDynamicEnvironment(String environment) {
@@ -580,8 +571,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
             return toRootPath();
         }
 
-        String result = toRootDir() + project + Constants.PATH_SEPARATOR + environment + Constants.PATH_SEPARATOR + URL.encode(name);
-        return result;
+        return toRootDir() + project + Constants.PATH_SEPARATOR + environment + Constants.PATH_SEPARATOR + URL.encode(name);
     }
 
     private String[] toCategoriesPath(URL url) {
@@ -632,7 +622,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
 
     private List<URL> toUrlsWithEmpty(URL consumer, String path, List<String> providers) {
         List<URL> urls = toUrlsWithoutEmpty(consumer, providers);
-        if (urls == null || urls.isEmpty()) {
+        if (urls.isEmpty()) {
             int i = path.lastIndexOf(PATH_SEPARATOR);
             String category = i < 0 ? path : path.substring(i + 1);
             URL empty = URLBuilder.from(consumer)


### PR DESCRIPTION
@forgivedengkai 

HealthCheckService作为一个spring-bean常驻内存，其中executor无任何引用且corePoolSize=availableProcessors()，相当于无效内存占用；并且因为HealthCheckService作为bean常驻内存，该executor也不会被JVM回收，故删除；

其余为代码简单优化；