### PR TITLE
Enhanced security header settings in serving admin

### DIFF
--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/filter/SecurityFilter.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/filter/SecurityFilter.java
@@ -29,7 +29,8 @@ public class SecurityFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain filterChain) throws IOException, ServletException {
-        ((HttpServletResponse) resp).addHeader("X-Frame-Options","DENY");
+        ((HttpServletResponse) resp).addHeader("X-Frame-Options", "DENY");
+        ((HttpServletResponse) resp).addHeader("X-XSS-Protection", "1; mode=block");
         filterChain.doFilter(req, resp);
     }
 }


### PR DESCRIPTION
@forgivedengkai 

1. serving-admin中增强安全头设置，通过X-XSS-Protection请求头设置来启用浏览器的内置跨站脚本（XSS）过滤器，并设置为1; mode=block，以指示浏览器在检测到可能的XSS攻击时，停止加载页面并阻止渲染。

2. 同时是否支持将X-Frame-Options的值由DENY改为SAMEORIGIN，以允许页面在同源域名下的框架中嵌入，这样可以允许合法的内嵌，同时阻止跨域的内嵌，增强页面扩展性？