### PR TITLE
serving-admin部分代码调整及简化

### DIFF
--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/bean/ServiceConfiguration.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/bean/ServiceConfiguration.java
@@ -44,8 +44,7 @@ public enum ServiceConfiguration {
             return Boolean.FALSE;
         }
 
-        boolean match = Arrays.asList(value.config).contains(config);
-        return match;
+        return Arrays.asList(value.config).contains(config);
     }
 
 }

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/config/WebConfig.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/config/WebConfig.java
@@ -72,8 +72,7 @@ public class WebConfig implements WebMvcConfigurer {
         Integer maxSize = MetaInfo.PROPERTY_LOCAL_CACHE_MAXSIZE;
         Integer expireTime = MetaInfo.PROPERTY_LOCAL_CACHE_EXPIRE;
         Integer interval = MetaInfo.PROPERTY_LOCAL_CACHE_INTERVAL;
-        ExpiringLRUCache lruCache = new ExpiringLRUCache(maxSize, expireTime, interval);
-        return lruCache;
+        return new ExpiringLRUCache(maxSize, expireTime, interval);
     }
 
 

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ModelController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ModelController.java
@@ -153,7 +153,6 @@ public class ModelController {
         return () -> {
             String host = requestParams.getHost();
             Integer port = requestParams.getPort();
-            List<String> serviceIds = requestParams.getServiceIds();
             String tableName = requestParams.getTableName();
             String namespace = requestParams.getNamespace();
 
@@ -175,13 +174,6 @@ public class ModelController {
             ModelServiceProto.FetchModelRequest   fetchModelRequest =  ModelServiceProto.FetchModelRequest.newBuilder()
                     //.setServiceId()
                     .setNamespace(namespace).setTableName(tableName).setSourceIp(host).setSourcePort(port).build();
-
-
-
-            ModelServiceProto.UnloadRequest unloadRequest = ModelServiceProto.UnloadRequest.newBuilder()
-                    .setTableName(tableName)
-                    .setNamespace(namespace)
-                    .build();
 
             ListenableFuture<ModelServiceProto.FetchModelResponse> future = futureStub.fetchModel(fetchModelRequest);
             ModelServiceProto.FetchModelResponse response = future.get(MetaInfo.PROPERTY_GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
@@ -308,8 +300,7 @@ public class ModelController {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        ModelServiceGrpc.ModelServiceFutureStub futureStub = ModelServiceGrpc.newFutureStub(managedChannel);
-        return futureStub;
+        return ModelServiceGrpc.newFutureStub(managedChannel);
     }
 
     public void parseComponentInfo(ModelServiceProto.QueryModelResponse response){

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/MonitorController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/MonitorController.java
@@ -287,8 +287,7 @@ public class MonitorController {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        CommonServiceGrpc.CommonServiceBlockingStub blockingStub = CommonServiceGrpc.newBlockingStub(managedChannel);
-        return blockingStub;
+        return CommonServiceGrpc.newBlockingStub(managedChannel);
     }
 
     private InferenceServiceGrpc.InferenceServiceBlockingStub getInferenceServiceBlockingStub(String host, int port, int timeout) throws Exception {
@@ -340,8 +339,8 @@ public class MonitorController {
             List currentList = currentComponentMap.get(serviceInfo.getHost() + ":" + port);
             Map<String,Object> currentInfoMap = new HashMap<>();
             currentInfoMap.put("type","inference");
-            if (result.getBody() == null || result.getBody().toStringUtf8() == "null") {
-                currentInfoMap.put("data",null);
+            if (result.getBody() == null || "null".equals(result.getBody().toStringUtf8())) {
+                currentInfoMap.put("data", null);
             }
             else{
                 Map resultMap = JsonUtil.json2Object(result.getBody().toStringUtf8(),Map.class);

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/RouterController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/RouterController.java
@@ -54,7 +54,7 @@ public class RouterController {
     ZookeeperRegistry zookeeperRegistry;
     @Autowired
     ComponentService componentService;
-    String ROUTER_URL = "proxy/online/queryRouter";
+    static final String ROUTER_URL = "proxy/online/queryRouter";
 
 
     @PostMapping("/router/query")

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ServiceController.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/controller/ServiceController.java
@@ -103,8 +103,9 @@ public class ServiceController {
                     URL url = URL.valueOf(u);
                     if (!Constants.EMPTY_PROTOCOL.equals(url.getProtocol())) {
                         String[] split = key.split("/");
-                        if(!filterSet.contains(split[2]))
+                        if (!filterSet.contains(split[2])) {
                             continue;
+                        }
                         ServiceDataWrapper wrapper = new ServiceDataWrapper();
                         wrapper.setUrl(url.toFullString());
                         wrapper.setProject(split[0]);
@@ -237,8 +238,7 @@ public class ServiceController {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        CommonServiceGrpc.CommonServiceFutureStub futureStub = CommonServiceGrpc.newFutureStub(managedChannel);
-        return futureStub;
+        return CommonServiceGrpc.newFutureStub(managedChannel);
     }
 
 }

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/interceptors/LoginInterceptor.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/interceptors/LoginInterceptor.java
@@ -43,7 +43,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     @Autowired
     private Cache cache;
 
-    private static List<String> EXCLUDES = Arrays.asList("/api/component/list", "/api/monitor/queryJvm", "/api/monitor/query", "/api/monitor/queryModel");
+    private static final List<String> EXCLUDES = Arrays.asList("/api/component/list", "/api/monitor/queryJvm", "/api/monitor/query", "/api/monitor/queryModel");
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/ComponentService.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/ComponentService.java
@@ -34,9 +34,8 @@ import java.util.*;
 @Service
 public class ComponentService {
 
-    private final static String PATH_SEPARATOR = "/";
-    private final static String DEFAULT_COMPONENT_ROOT = "FATE-COMPONENTS";
-    private final static String PROVIDER = "providers";
+    private static final String PATH_SEPARATOR = "/";
+    private static final String DEFAULT_COMPONENT_ROOT = "FATE-COMPONENTS";
     Logger logger = LoggerFactory.getLogger(ComponentService.class);
     @Autowired
     ZookeeperRegistry zookeeperRegistry;
@@ -88,10 +87,7 @@ public class ComponentService {
             }
             return false;
         }).map(Map.Entry::getKey).findFirst();
-        if(project.isPresent())
-            return project.get();
-        else
-            return "";
+        return project.orElse("");
     }
 
     public boolean isAllowAccess(String host, int port) {

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/HealthCheckService.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/HealthCheckService.java
@@ -47,18 +47,17 @@ public class HealthCheckService implements InitializingBean {
     GrpcConnectionPool grpcConnectionPool = GrpcConnectionPool.getPool();
     Map<String,Object> healthRecord = new ConcurrentHashMap<>();
 
-    private static ThreadPoolExecutor executor = ThreadPoolUtil.newThreadPoolExecutor();
-
     public    Map  getHealthCheckInfo(){
         return   healthRecord;
     }
 
     private void  checkRemoteHealth(Map<String,Map> componentMap, String address, String component) {
-        if(StringUtils.isBlank(address))
+        if (StringUtils.isBlank(address)) {
             return ;
+        }
         Map<String,Map> currentComponentMap = componentMap.get(component);
-        String host = address.substring(0,address.indexOf(":"));
-        int port = Integer.parseInt(address.substring(address.indexOf(":") + 1));
+        String host = address.substring(0,address.indexOf(':'));
+        int port = Integer.parseInt(address.substring(address.indexOf(':') + 1));
         CommonServiceGrpc.CommonServiceBlockingStub blockingStub = getMonitorServiceBlockStub(host, port);
         CommonServiceProto.HealthCheckRequest.Builder builder = CommonServiceProto.HealthCheckRequest.newBuilder();
         CommonServiceProto.CommonResponse commonResponse = blockingStub.checkHealthService(builder.build());
@@ -150,8 +149,7 @@ public class HealthCheckService implements InitializingBean {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        CommonServiceGrpc.CommonServiceBlockingStub blockingStub = CommonServiceGrpc.newBlockingStub(managedChannel);
-        return blockingStub;
+        return CommonServiceGrpc.newBlockingStub(managedChannel);
     }
     @Override
     public void afterPropertiesSet() throws Exception {

--- a/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/provider/ValidateServiceProvider.java
+++ b/fate-serving-admin/src/main/java/com/webank/ai/fate/serving/admin/services/provider/ValidateServiceProvider.java
@@ -149,8 +149,7 @@ public class ValidateServiceProvider extends AbstractAdminServiceProvider {
         ListenableFuture<InferenceServiceProto.InferenceMessage> future = inferenceServiceFutureStub.inference(builder.build());
         InferenceServiceProto.InferenceMessage response = future.get(MetaInfo.PROPERTY_GRPC_TIMEOUT * 2, TimeUnit.MILLISECONDS);
 
-        Map returnResult = JsonUtil.json2Object(response.getBody().toStringUtf8(), Map.class);
-        return returnResult;
+        return JsonUtil.json2Object(response.getBody().toStringUtf8(), Map.class);
     }
 
     @FateServiceMethod(name = "batchInference")
@@ -201,8 +200,7 @@ public class ValidateServiceProvider extends AbstractAdminServiceProvider {
         ListenableFuture<InferenceServiceProto.InferenceMessage> future = inferenceServiceFutureStub.batchInference(builder.build());
         InferenceServiceProto.InferenceMessage response = future.get(MetaInfo.PROPERTY_GRPC_TIMEOUT * 2, TimeUnit.MILLISECONDS);
 
-        Map returnResult = JsonUtil.json2Object(response.getBody().toStringUtf8(), Map.class);
-        return returnResult;
+        return JsonUtil.json2Object(response.getBody().toStringUtf8(), Map.class);
     }
 
     /*private ModelServiceProto.PublishRequest buildPublishRequest(Map params) {
@@ -265,7 +263,6 @@ public class ValidateServiceProvider extends AbstractAdminServiceProvider {
 
     @Override
     protected Object transformExceptionInfo(Context context, ExceptionInfo data) {
-        String actionType = context.getActionType();
         Map returnResult = new HashMap();
         if (data != null) {
             int code = data.getCode();
@@ -302,8 +299,7 @@ public class ValidateServiceProvider extends AbstractAdminServiceProvider {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        ModelServiceGrpc.ModelServiceFutureStub futureStub = ModelServiceGrpc.newFutureStub(managedChannel);
-        return futureStub;
+        return ModelServiceGrpc.newFutureStub(managedChannel);
     }
 
     private InferenceServiceGrpc.InferenceServiceFutureStub getInferenceServiceFutureStub(String host, Integer port) throws Exception {
@@ -316,7 +312,6 @@ public class ValidateServiceProvider extends AbstractAdminServiceProvider {
         }
 
         ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
-        InferenceServiceGrpc.InferenceServiceFutureStub futureStub = InferenceServiceGrpc.newFutureStub(managedChannel);
-        return futureStub;
+        return InferenceServiceGrpc.newFutureStub(managedChannel);
     }
 }


### PR DESCRIPTION
@forgivedengkai 
1. 部分函数返回无需进行变量存储，直接rerurn返回即可，简化代码
2. 部分无引用变量去除
3. 字符串之间的比对应用equals()方法而非 ==
4. 部分不可变常量增加static final 声明
5. final及static对于不可变常量的声明遵从JCS规范，static在前，final在后