### PR TITLE
serving-server add model unbind rest interface

### DIFF
--- a/fate-serving-server/pom.xml
+++ b/fate-serving-server/pom.xml
@@ -102,6 +102,16 @@
         <artifactId>protobuf-java-format</artifactId>
         <version>1.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fate-serving-server/src/main/java/com/webank/ai/fate/serving/controller/ServerController.java
+++ b/fate-serving-server/src/main/java/com/webank/ai/fate/serving/controller/ServerController.java
@@ -1,0 +1,83 @@
+package com.webank.ai.fate.serving.controller;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.webank.ai.fate.api.mlmodel.manager.ModelServiceGrpc;
+import com.webank.ai.fate.api.mlmodel.manager.ModelServiceProto;
+import com.webank.ai.fate.serving.core.bean.GrpcConnectionPool;
+import com.webank.ai.fate.serving.core.bean.MetaInfo;
+import com.webank.ai.fate.serving.core.bean.RequestParamWrapper;
+import com.webank.ai.fate.serving.core.bean.ReturnResult;
+import com.webank.ai.fate.serving.core.exceptions.SysException;
+import com.webank.ai.fate.serving.core.utils.NetUtils;
+import io.grpc.ManagedChannel;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author hcy
+ */
+@RestController
+public class ServerController {
+
+    Logger logger = LoggerFactory.getLogger(ServerController.class);
+
+    GrpcConnectionPool grpcConnectionPool = GrpcConnectionPool.getPool();
+
+    @RequestMapping(value = "/server/model/unbind", method = RequestMethod.POST)
+    @ResponseBody
+    public Callable<ReturnResult> unbind(@RequestBody RequestParamWrapper requestParams) throws Exception {
+        return () -> {
+            String host = requestParams.getHost();
+            Integer port = requestParams.getPort();
+            String tableName = requestParams.getTableName();
+            String namespace = requestParams.getNamespace();
+            List<String> serviceIds = requestParams.getServiceIds();
+
+            Preconditions.checkArgument(StringUtils.isNotBlank(tableName), "parameter tableName is blank");
+            Preconditions.checkArgument(StringUtils.isNotBlank(namespace), "parameter namespace is blank");
+            Preconditions.checkArgument(serviceIds != null && serviceIds.size() != 0, "parameter serviceId is blank");
+
+            ReturnResult result = new ReturnResult();
+
+            logger.info("unbind model by tableName and namespace, host: {}, port: {}, tableName: {}, namespace: {}", host, port, tableName, namespace);
+
+            ModelServiceGrpc.ModelServiceFutureStub futureStub = getModelServiceFutureStub(host, port);
+
+            ModelServiceProto.UnbindRequest unbindRequest = ModelServiceProto.UnbindRequest.newBuilder()
+                    .setTableName(tableName)
+                    .setNamespace(namespace)
+                    .addAllServiceIds(serviceIds)
+                    .build();
+
+            ListenableFuture<ModelServiceProto.UnbindResponse> future = futureStub.unbind(unbindRequest);
+
+            ModelServiceProto.UnbindResponse response = future.get(MetaInfo.PROPERTY_GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
+
+            logger.info("response: {}", response);
+
+            result.setRetcode(response.getStatusCode());
+            result.setRetmsg(response.getMessage());
+            return result;
+        };
+    }
+
+    private ModelServiceGrpc.ModelServiceFutureStub getModelServiceFutureStub(String host, Integer port) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(host), "parameter host is blank");
+        Preconditions.checkArgument(port != null && port != 0, "parameter port was wrong");
+
+        if (!NetUtils.isValidAddress(host + ":" + port)) {
+            throw new SysException("invalid address");
+        }
+
+        ManagedChannel managedChannel = grpcConnectionPool.getManagedChannel(host, port);
+        return ModelServiceGrpc.newFutureStub(managedChannel);
+    }
+}


### PR DESCRIPTION
@forgivedengkai 

测试结论：

zk中测试用serviceId对应节点下/FATE-SERVICES/serving/64f59b37e4b038cc11e9baf5/inference/providers已被清空
![ba139fc4a4c3981091c7a5907ead757](https://github.com/FederatedAI/FATE-Serving/assets/21000499/16deee43-c2a9-4adf-a853-dd1fde5b0bc7)

请求调用serving-server新增的model unbind接口
![7b3baca5abc41a7778b80b11baed6cd](https://github.com/FederatedAI/FATE-Serving/assets/21000499/a1f5c902-6f92-47b5-9471-1f9d734a2910)

serving-server接收到请求并完成处理
![894effcba2e5642f40b6d6f940d7de0](https://github.com/FederatedAI/FATE-Serving/assets/21000499/3d6b8f26-3689-4b23-bd86-7a6ed91c0caa)

