### PR TITLE
新增JVM中线程CPU占比信息数据统计

### DIFF
--- a/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/bean/ThreadVO.java
+++ b/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/bean/ThreadVO.java
@@ -1,0 +1,146 @@
+package com.webank.ai.fate.serving.common.bean;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * @author hcy
+ */
+public class ThreadVO implements Serializable {
+    private static final long serialVersionUID = 0L;
+
+    private long id;
+    private String name;
+    private String group;
+    private int priority;
+    private Thread.State state;
+    private double cpu;
+    private long deltaTime;
+    private long time;
+    private boolean interrupted;
+    private boolean daemon;
+
+    public ThreadVO() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public Thread.State getState() {
+        return state;
+    }
+
+    public void setState(Thread.State state) {
+        this.state = state;
+    }
+
+    public double getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(double cpu) {
+        this.cpu = cpu;
+    }
+
+    public long getDeltaTime() {
+        return deltaTime;
+    }
+
+    public void setDeltaTime(long deltaTime) {
+        this.deltaTime = deltaTime;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public boolean isInterrupted() {
+        return interrupted;
+    }
+
+    public void setInterrupted(boolean interrupted) {
+        this.interrupted = interrupted;
+    }
+
+    public boolean isDaemon() {
+        return daemon;
+    }
+
+    public void setDaemon(boolean daemon) {
+        this.daemon = daemon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ThreadVO threadVO = (ThreadVO) o;
+
+        if (id != threadVO.id) {
+            return false;
+        }
+        return Objects.equals(name, threadVO.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ThreadVO{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", group='" + group + '\'' +
+                ", priority=" + priority +
+                ", state=" + state +
+                ", cpu=" + cpu +
+                ", deltaTime=" + deltaTime +
+                ", time=" + time +
+                ", interrupted=" + interrupted +
+                ", daemon=" + daemon +
+                '}';
+    }
+}

--- a/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/JVMCPUUtils.java
+++ b/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/JVMCPUUtils.java
@@ -1,0 +1,39 @@
+package com.webank.ai.fate.serving.common.utils;
+
+import com.webank.ai.fate.serving.common.bean.ThreadVO;
+
+import java.util.*;
+
+/**
+ * @author hcy
+ */
+public class JVMCPUUtils {
+
+    private static Set<String> states = null;
+
+    static {
+        states = new HashSet<>(Thread.State.values().length);
+        for (Thread.State state : Thread.State.values()) {
+            states.add(state.name());
+        }
+    }
+
+    public static List<ThreadVO> getThreadsState() {
+
+        List<ThreadVO> threads = ThreadUtils.getThreads();
+
+        Collection<ThreadVO> resultThreads = new ArrayList<>();
+        for (ThreadVO thread : threads) {
+            if (thread.getState() != null && states.contains(thread.getState().name())) {
+                resultThreads.add(thread);
+            }
+        }
+
+
+        ThreadSampler threadSampler = new ThreadSampler();
+        threadSampler.setIncludeInternalThreads(true);
+        threadSampler.sample(resultThreads);
+        threadSampler.pause(1000);
+        return threadSampler.sample(resultThreads);
+    }
+}

--- a/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/ThreadSample.java
+++ b/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/ThreadSample.java
@@ -1,0 +1,200 @@
+package com.webank.ai.fate.serving.common.utils;
+
+
+import com.webank.ai.fate.serving.common.bean.ThreadVO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.management.HotspotThreadMBean;
+import sun.management.ManagementFactoryHelper;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author hcy
+ */
+
+class ThreadSampler {
+    private static Logger logger = LoggerFactory.getLogger(ThreadSampler.class);
+    private static ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    private static HotspotThreadMBean hotspotThreadMBean;
+    private static boolean hotspotThreadMBeanEnable = true;
+
+    private Map<ThreadVO, Long> lastCpuTimes = new HashMap<ThreadVO, Long>();
+
+    private long lastSampleTimeNanos;
+    private boolean includeInternalThreads = true;
+
+
+    public List<ThreadVO> sample(Collection<ThreadVO> originThreads) {
+
+        List<ThreadVO> threads = new ArrayList<ThreadVO>(originThreads);
+
+        // Sample CPU
+        if (lastCpuTimes.isEmpty()) {
+            lastSampleTimeNanos = System.nanoTime();
+            for (ThreadVO thread : threads) {
+                if (thread.getId() > 0) {
+                    long cpu = threadMXBean.getThreadCpuTime(thread.getId());
+                    lastCpuTimes.put(thread, cpu);
+                    thread.setTime(cpu / 1000000);
+                }
+            }
+
+            // add internal threads
+            Map<String, Long> internalThreadCpuTimes = getInternalThreadCpuTimes();
+            if (internalThreadCpuTimes != null) {
+                for (Map.Entry<String, Long> entry : internalThreadCpuTimes.entrySet()) {
+                    String key = entry.getKey();
+                    ThreadVO thread = createThreadVO(key);
+                    thread.setTime(entry.getValue() / 1000000);
+                    threads.add(thread);
+                    lastCpuTimes.put(thread, entry.getValue());
+                }
+            }
+
+            //sort by time
+            Collections.sort(threads, new Comparator<ThreadVO>() {
+                @Override
+                public int compare(ThreadVO o1, ThreadVO o2) {
+                    long l1 = o1.getTime();
+                    long l2 = o2.getTime();
+                    if (l1 < l2) {
+                        return 1;
+                    } else if (l1 > l2) {
+                        return -1;
+                    } else {
+                        return 0;
+                    }
+                }
+            });
+            return threads;
+        }
+
+        // Resample
+        long newSampleTimeNanos = System.nanoTime();
+        Map<ThreadVO, Long> newCpuTimes = new HashMap<ThreadVO, Long>(threads.size());
+        for (ThreadVO thread : threads) {
+            if (thread.getId() > 0) {
+                long cpu = threadMXBean.getThreadCpuTime(thread.getId());
+                newCpuTimes.put(thread, cpu);
+            }
+        }
+        // internal threads
+        Map<String, Long> newInternalThreadCpuTimes = getInternalThreadCpuTimes();
+        if (newInternalThreadCpuTimes != null) {
+            for (Map.Entry<String, Long> entry : newInternalThreadCpuTimes.entrySet()) {
+                ThreadVO threadVO = createThreadVO(entry.getKey());
+                threads.add(threadVO);
+                newCpuTimes.put(threadVO, entry.getValue());
+            }
+        }
+
+        // Compute delta time
+        final Map<ThreadVO, Long> deltas = new HashMap<ThreadVO, Long>(threads.size());
+        for (ThreadVO thread : newCpuTimes.keySet()) {
+            Long t = lastCpuTimes.get(thread);
+            if (t == null) {
+                t = 0L;
+            }
+            long time1 = t;
+            long time2 = newCpuTimes.get(thread);
+            if (time1 == -1) {
+                time1 = time2;
+            } else if (time2 == -1) {
+                time2 = time1;
+            }
+            long delta = time2 - time1;
+            deltas.put(thread, delta);
+        }
+
+        long sampleIntervalNanos = newSampleTimeNanos - lastSampleTimeNanos;
+
+        // Compute cpu usage
+        final HashMap<ThreadVO, Double> cpuUsages = new HashMap<ThreadVO, Double>(threads.size());
+        for (ThreadVO thread : threads) {
+            double cpu = sampleIntervalNanos == 0 ? 0 : (Math.rint(deltas.get(thread) * 10000.0 / sampleIntervalNanos) / 100.0);
+            cpuUsages.put(thread, cpu);
+        }
+
+        // Sort by CPU time : should be a rendering hint...
+        Collections.sort(threads, new Comparator<ThreadVO>() {
+            @Override
+            public int compare(ThreadVO o1, ThreadVO o2) {
+                long l1 = deltas.get(o1);
+                long l2 = deltas.get(o2);
+                if (l1 < l2) {
+                    return 1;
+                } else if (l1 > l2) {
+                    return -1;
+                } else {
+                    return 0;
+                }
+            }
+        });
+
+        for (ThreadVO thread : threads) {
+            //nanos to mills
+            long timeMills = newCpuTimes.get(thread) / 1000000;
+            long deltaTime = deltas.get(thread) / 1000000;
+            double cpu = cpuUsages.get(thread);
+
+            thread.setCpu(cpu);
+            thread.setTime(timeMills);
+            thread.setDeltaTime(deltaTime);
+        }
+        lastCpuTimes = newCpuTimes;
+        lastSampleTimeNanos = newSampleTimeNanos;
+
+        return threads;
+    }
+
+    private Map<String, Long> getInternalThreadCpuTimes() {
+        if (hotspotThreadMBeanEnable && includeInternalThreads) {
+            try {
+                if (hotspotThreadMBean == null) {
+                    hotspotThreadMBean = ManagementFactoryHelper.getHotspotThreadMBean();
+                }
+                return hotspotThreadMBean.getInternalThreadCpuTimes();
+            } catch (Exception ex) {
+                logger.error("getInternalThreadCpuTimes failed Cause : " + ex);
+                hotspotThreadMBeanEnable = false;
+            }
+        }
+        return null;
+    }
+
+    private ThreadVO createThreadVO(String name) {
+        ThreadVO threadVO = new ThreadVO();
+        threadVO.setId(-1);
+        threadVO.setName(name);
+        threadVO.setPriority(-1);
+        threadVO.setDaemon(true);
+        threadVO.setInterrupted(false);
+        return threadVO;
+    }
+
+    public void pause(long mills) {
+        try {
+            Thread.sleep(mills);
+        } catch (InterruptedException e) {
+            logger.error("pause failed Cause : " + e);
+        }
+    }
+
+    public boolean isIncludeInternalThreads() {
+        return includeInternalThreads;
+    }
+
+    public void setIncludeInternalThreads(boolean includeInternalThreads) {
+        this.includeInternalThreads = includeInternalThreads;
+    }
+}
+

--- a/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/ThreadUtils.java
+++ b/fate-serving-common/src/main/java/com/webank/ai/fate/serving/common/utils/ThreadUtils.java
@@ -1,0 +1,50 @@
+package com.webank.ai.fate.serving.common.utils;
+
+import com.webank.ai.fate.serving.common.bean.ThreadVO;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author hcy
+ */
+public class ThreadUtils {
+
+    private static ThreadGroup getRoot() {
+        ThreadGroup group = Thread.currentThread().getThreadGroup();
+        ThreadGroup parent;
+        while ((parent = group.getParent()) != null) {
+            group = parent;
+        }
+        return group;
+    }
+
+    public static List<ThreadVO> getThreads() {
+        ThreadGroup root = getRoot();
+        Thread[] threads = new Thread[root.activeCount()];
+        while (root.enumerate(threads, true) == threads.length) {
+            threads = new Thread[threads.length * 2];
+        }
+        List<ThreadVO> list = new ArrayList<ThreadVO>(threads.length);
+        for (Thread thread : threads) {
+            if (thread != null) {
+                ThreadVO threadVO = createThreadVO(thread);
+                list.add(threadVO);
+            }
+        }
+        return list;
+    }
+
+    private static ThreadVO createThreadVO(Thread thread) {
+        ThreadGroup group = thread.getThreadGroup();
+        ThreadVO threadVO = new ThreadVO();
+        threadVO.setId(thread.getId());
+        threadVO.setName(thread.getName());
+        threadVO.setGroup(group == null ? "" : group.getName());
+        threadVO.setPriority(thread.getPriority());
+        threadVO.setState(thread.getState());
+        threadVO.setInterrupted(thread.isInterrupted());
+        threadVO.setDaemon(thread.isDaemon());
+        return threadVO;
+    }
+}


### PR DESCRIPTION
@forgivedengkai 

实现原理：
参考arthas中关于CPU时间片的占比统计方式，如下

- 首先第一次采样，获取所有线程的 CPU 时间(调用的是`java.lang.management.ThreadMXBean#getThreadCpuTime()`及`sun.management.HotspotThreadMBean.getInternalThreadCpuTimes()`接口)
- 然后睡眠等待一个间隔时间（默认为 200ms，可以通过`-i`指定间隔时间）
- 再次第二次采样，获取所有线程的 CPU 时间，对比两次采样数据，计算出每个线程的增量 CPU 时间
- 线程 CPU 使用率 = 线程增量 CPU 时间 / 采样间隔时间 \* 100%

测试截图：

![image](https://github.com/FederatedAI/FATE-Serving/assets/21000499/5d91db51-9e09-4b9e-bf59-4f7b562e0d77)
