### PR TITLE
httpAdapter实现更新

### DIFF
--- a/document/docs/service/adapter.md
+++ b/document/docs/service/adapter.md
@@ -69,7 +69,7 @@ x0:1,x1:5,x2:13,x3:58,x4:95,x5:352,x6:418,x7:833,x8:888,x9:937,x10:32776
 
 #### HttpAdapter
 在serving-server.properties文件中配置属性feature.single.adaptor和http.adapter.url，feature.single.adaptor为继承AbstractSingleFeatureDataAdaptor
-接口，url为调用获取数据接口地址。  
+接口，url为调用获取数据接口地址。http.adapter.url中标明的用户接口，返回格式请定义为 {"code": 200, "data": xxx}标准格式即可，httpAdapter中会根据接口返回状态码是否为200判断用户数据拉取接口是否执行成功。
 ```yaml
 feature.single.adaptor=com.webank.ai.fate.serving.adaptor.dataaccess.HttpAdapter
 http.adapter.url=http://127.0.0.1:9380/v1/http/adapter/getFeature


### PR DESCRIPTION
@forgivedengkai 

1. httpAdapter需要调用用户自己业务产品代码中的拉取接口，按照原有实现，直接通过状态码判断只能判断本次请求是否成功，因为采用的状态码是httpSevletResponse的code，并非用户接口是否成功的code；所以需要进行二次判断，建议用户的接口返回标准定义为{"code": 200, "data": xxx}；

2. 其次原本逻辑中对于状态码的判断是跟200进行判断，但是httpSevletResponse中的成功返回码为0，所以无法成功，需要改为跟0进行判断，而用户接口的code则采用标准业务码200进行判断；

3. 同步更新httpAdapter对应md文件。

验证截图：

![image](https://github.com/FederatedAI/FATE-Serving/assets/21000499/51d9e17c-a3f2-4fe5-a69e-82293d0c3899)
